### PR TITLE
Page spacing correction

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}.tex
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}.tex
@@ -2,6 +2,7 @@
 english, % document language
 a4paper, %paper type
 twoside, % two sided printing
+twoside=semi,
 %openright, % start new chapter on right side only ( inserts blank pages )
 DIV=11,      % This parameter organizes the borders (detailed explanation at http://texdoc.net/texmf-dist/doc/latex/koma-script/scrguide.pdf
 BCOR=8mm]{scrbook} % BCOR sets the space, used by the type of  book. (e.g. glued, hard cover..)


### PR DESCRIPTION
In this pull request, I suggest an additional parameter to fix the left and right margin space in the pages. When printing one should expect to have a bigger margin on the inner side than on the outer side to paste together all the sheets. Originally the margin space in inverted, but with this additional line it gets fixed.